### PR TITLE
Image search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Brave Search API Wrapper
 
-A fully typed Brave Search API wrapper, providing easy access to web search, local POI search, and automatic polling for AI-generated web search summary feature.
+A fully typed Brave Search API wrapper, providing easy access to web search, image search, local POI search, and automatic polling for AI-generated web search summary feature.
 
 ## Installation
 
@@ -107,6 +107,20 @@ Get descriptions for local points of interest using the `localDescriptionsSearch
 ```typescript
 const descriptionResults = await braveSearch.localDescriptionsSearch(["poi_id1", "poi_id2"]);
 console.log(descriptionResults);
+```
+
+### Image Search 
+
+Perform an image search using the `imageSearch` method. Your IDE will provide type hints for the parameters and return types.
+
+```typescript
+const imageSearchResults = await braveSearch.imageSearch("Golden Gate Bridge", {
+  count: 5,
+  safesearch: "off",
+  search_lang: "en",
+  country: "US",
+});
+console.log(imageSearchResults);
 ```
 
 ## Search Options

--- a/src/braveSearch.ts
+++ b/src/braveSearch.ts
@@ -21,6 +21,7 @@ const DEFAULT_MAX_POLL_ATTEMPTS = 20;
 import {
   BraveSearchOptions,
   ImageSearchApiResponse,
+  ImageSearchOptions,
   LocalDescriptionsSearchApiResponse,
   LocalPoiSearchApiResponse,
   PollingOptions,
@@ -100,7 +101,7 @@ class BraveSearch {
     }
   }
 
-    /**
+  /**
    * Performs an image search using the provided query and options.
    * @param query The search query string.
    * @param options Optional settings to configure the search behavior.
@@ -108,7 +109,7 @@ class BraveSearch {
    */
   async imageSearch(
     query: string,
-    options: BraveSearchOptions = {},
+    options: ImageSearchOptions = {},
     signal?: AbortSignal,
   ): Promise<ImageSearchApiResponse> {
     const params = new URLSearchParams({
@@ -321,6 +322,7 @@ export {
   BraveSearch,
   BraveSearchError,
   type BraveSearchOptions,
+  type ImageSearchOptions,
   type LocalDescriptionsSearchApiResponse,
   type LocalPoiSearchApiResponse,
   type SummarizerOptions,

--- a/src/braveSearch.ts
+++ b/src/braveSearch.ts
@@ -20,6 +20,7 @@ const DEFAULT_MAX_POLL_ATTEMPTS = 20;
 
 import {
   BraveSearchOptions,
+  ImageSearchApiResponse,
   LocalDescriptionsSearchApiResponse,
   LocalPoiSearchApiResponse,
   PollingOptions,
@@ -49,7 +50,7 @@ class BraveSearchError extends Error {
 
 /**
  * The main class for interacting with the Brave Search API, holding API key for all the requests made with it.
- * It provides methods for web search, local POI search, and summarization.
+ * It provides methods for web search, image search, local POI search, and summarization.
  */
 class BraveSearch {
   private apiKey: string;
@@ -92,6 +93,36 @@ class BraveSearch {
           signal,
         },
       );
+      return response.data;
+    } catch (error) {
+      const handledError = this.handleApiError(error);
+      throw handledError;
+    }
+  }
+
+    /**
+   * Performs an image search using the provided query and options.
+   * @param query The search query string.
+   * @param options Optional settings to configure the search behavior.
+   * @returns A promise that resolves to the image search results.
+   */
+  async imageSearch(
+    query: string,
+    options: BraveSearchOptions = {},
+    signal?: AbortSignal,
+  ): Promise<ImageSearchApiResponse> {
+    const params = new URLSearchParams({
+      q: query,
+      ...this.formatOptions(options),
+    })
+    try {
+      const response = await axios.get<ImageSearchApiResponse>(
+        `${this.baseUrl}/images/search?${params.toString()}`,
+        {
+          headers: this.getHeaders(),
+          signal,
+        }
+      )
       return response.data;
     } catch (error) {
       const handledError = this.handleApiError(error);
@@ -295,4 +326,5 @@ export {
   type SummarizerOptions,
   type SummarizerSearchApiResponse,
   type WebSearchApiResponse,
+  type ImageSearchApiResponse,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -2598,3 +2598,92 @@ export interface Image {
    */
   properties: ImageProperties;
 }
+
+  /**
+   * Response from the Brave Search API for an Image search
+   * 
+   * https://api-dashboard.search.brave.com/app/documentation/image-search/responses
+   */
+  export interface ImageSearchApiResponse {
+    /**
+     * The type of search API result. The value is always images.
+     * @type {string}
+     */
+    type: 'images'
+    /**
+     * Image search query string.
+     * @type {Query}
+     */
+    query: Query
+    /**
+     * The list of image results for the given query.
+     * @type {ImageResult[]}
+     */
+    results: ImageResult[]
+  }
+
+  /**
+   * A model representing an image result for the requested query.
+   * 
+   * https://api-dashboard.search.brave.com/app/documentation/image-search/responses#ImageResult
+   */
+  export interface ImageResult {
+    /**
+     * The type of image search API result. The value is always image_result.
+     * @type {string}
+     */
+    type: 'image_result'
+    /**
+     * The title of the image.
+     * @type {string} 
+     */
+    title: string
+    /**
+     * The original page url where the image was found.
+     * @type {string}
+     */
+    url: string
+    /**
+     * The source domain where the image was found.
+     * @type {string}
+     */
+    source: string
+    /**
+     * The iso date time when the page was last fetched. The format is YYYY-MM-DDTHH:MM:SSZ
+     * @type {string}
+     */
+    page_fetched: string
+    /**
+     * The thumbnail for the image.
+     * @type {Thumbnail}
+     */
+    thumbnail: Thumbnail
+    /**
+     * Metadata for the image
+     * @type {Properties}
+     */
+    properties: Properties
+    /**
+     * Aggregated information on the url associated with the image search result.
+     * @type {MetaUrl}
+     */
+    meta_url: MetaUrl
+  }
+
+  /**
+   * Metadata on an image.
+   * 
+   * https://api-dashboard.search.brave.com/app/documentation/image-search/responses#Properties
+   */
+  export interface Properties {
+    /**
+     * The image URL.
+     * @type {string}
+     */
+    url: string
+    /**
+     * The lower resolution placeholder image url.
+     * @type {string}
+     */
+    placeholder: string
+  }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2600,6 +2600,14 @@ export interface Image {
 }
 
   /**
+   * Options for image search
+   * 
+   * https://api-dashboard.search.brave.com/app/documentation/image-search/query
+   */
+  export interface ImageSearchOptions extends Pick<BraveSearchOptions, 'country' | 'search_lang' | 'safesearch' | 'spellcheck' | 'count'> {
+  }
+
+  /**
    * Response from the Brave Search API for an Image search
    * 
    * https://api-dashboard.search.brave.com/app/documentation/image-search/responses


### PR DESCRIPTION
Adds the ability to do an image search by using Brave Search Image Search API.

Includes typescript interfaces that corresponds to image search response object
https://api-dashboard.search.brave.com/app/documentation/image-search/responses

One thing I am not sure about is the Query Parameters for Image search. (https://api-dashboard.search.brave.com/app/documentation/image-search/query) It seems to be subset of the Web Search query parameters. I tested locally the imageSearch method with the  web query param of 'freshness' which is not in the image query parameters. It is just ignored. It might create confusion for users that use IDE to suggest/autocomplete parameters.