### PR TITLE
Add news search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Brave Search API Wrapper
 
-A fully typed Brave Search API wrapper, providing easy access to web search, image search, local POI search, and automatic polling for AI-generated web search summary feature.
+A fully typed Brave Search API wrapper, providing easy access to web search, news search, image search, local POI search, and automatic polling for AI-generated web search summary feature.
 
 ## Installation
 
@@ -121,6 +121,19 @@ const imageSearchResults = await braveSearch.imageSearch("Golden Gate Bridge", {
   country: "US",
 });
 console.log(imageSearchResults);
+```
+
+### News Search
+
+Perform a News search using the 'newsSearch` method. Your IDE will provide type hints for the parameters and return types.
+
+```typescript
+const newsSearchResults = await braveSearch.newsSearch("Ghibli ChatGPT", {
+  count: 5, // Number of search results to return
+  search_lang: "en", // Optional: Language of the search results (default is "en")
+  extra_snippets: true, // Optional: Whether to include extra snippets (default is false)
+});
+console.log(newsSearchResults);
 ```
 
 ## Search Options

--- a/src/braveSearch.ts
+++ b/src/braveSearch.ts
@@ -138,15 +138,14 @@ class BraveSearch {
     options: NewsSearchOptions = {},
     signal?: AbortSignal,
   ) : Promise<NewsSearchApiResponse> {
-    const params = new URLSearchParams({
-      q: query,
-      ...this.formatOptions(options),
-    });
-
     try {
       const response = await axios.get<NewsSearchApiResponse>(
-        `${this.baseUrl}/news/search?${params.toString()}`,
+        `${this.baseUrl}/news/search?`,
         {
+          params: {
+            q: query,
+            ...this.formatOptions(options),
+          },
           headers: this.getHeaders(),
           signal,
         },

--- a/src/braveSearch.ts
+++ b/src/braveSearch.ts
@@ -24,6 +24,8 @@ import {
   ImageSearchOptions,
   LocalDescriptionsSearchApiResponse,
   LocalPoiSearchApiResponse,
+  NewsSearchApiResponse,
+  NewsSearchOptions,
   PollingOptions,
   SummarizerOptions,
   SummarizerSearchApiResponse,
@@ -124,6 +126,31 @@ class BraveSearch {
           signal,
         }
       )
+      return response.data;
+    } catch (error) {
+      const handledError = this.handleApiError(error);
+      throw handledError;
+    }
+  }
+
+  async newsSearch(
+    query: string,
+    options: NewsSearchOptions = {},
+    signal?: AbortSignal,
+  ) : Promise<NewsSearchApiResponse> {
+    const params = new URLSearchParams({
+      q: query,
+      ...this.formatOptions(options),
+    });
+
+    try {
+      const response = await axios.get<NewsSearchApiResponse>(
+        `${this.baseUrl}/news/search?${params.toString()}`,
+        {
+          headers: this.getHeaders(),
+          signal,
+        },
+      );
       return response.data;
     } catch (error) {
       const handledError = this.handleApiError(error);
@@ -329,4 +356,6 @@ export {
   type SummarizerSearchApiResponse,
   type WebSearchApiResponse,
   type ImageSearchApiResponse,
+  type NewsSearchApiResponse,
+  type NewsSearchOptions,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -2695,3 +2695,34 @@ export interface Image {
      */
     placeholder: string
   }
+
+  /**
+   * Options for news search
+   * 
+   * https://api-dashboard.search.brave.com/app/documentation/news-search/query
+   */
+  export interface NewsSearchOptions extends Pick<BraveSearchOptions, 'country' | 'search_lang' | 'ui_lang' | 'count' | 'offset' | 'spellcheck' | 'safesearch' | 'freshness' | 'extra_snippets'> {
+  }
+
+  /**
+   * Response from the Brave Search API for a News search
+   * 
+   * https://api-dashboard.search.brave.com/app/documentation/news-search/responses#NewsSearchApiResponse
+   */
+  export interface NewsSearchApiResponse {
+    /**
+     * The type of search API result. The value is always news.
+     * @type {string}
+     */
+    type: 'news'
+    /**
+     * 	News search query string.
+     * * @type {Query}
+     */
+    query: Query
+    /**
+     * The list of news results for the given query.
+     * @type {NewsResult[]}
+     */
+    results: NewsResult[]
+  }


### PR DESCRIPTION
Hello again,

I have added news search to match up with https://api-dashboard.search.brave.com/app/documentation/news-search/get-started.

One thing I am not sure about is the breaking field in the NewsResult response object. In the brave api docs for [NewsResult](https://api-dashboard.search.brave.com/app/documentation/news-search/responses#NewsResult) there is breaking field which matches the existing NewsResult interface in types.ts. However when I make a request to https://api.search.brave.com/res/v1/news/search there is no breaking in the response. But if I make a request to https://api.search.brave.com/res/v1/web/search with the param result_filter=news breaking is in the response. Looks like something on brave's end??

On a separate note. axios is at 1.7.2 in the package-lock.json which has a security issue. https://github.com/advisories/GHSA-jr5f-v2jv-69x6

Mike