### PR TITLE
Change the way ids are handled for localPoiSearch and localDescriptionsSearch

### DIFF
--- a/src/braveSearch.ts
+++ b/src/braveSearch.ts
@@ -202,8 +202,9 @@ class BraveSearch {
       const response = await axios.get<LocalPoiSearchApiResponse>(
         `${this.baseUrl}/local/pois`,
         {
-          params: {
-            ids: ids.join(","),
+          params: { ids },
+          paramsSerializer: {
+            indexes: null
           },
           headers: this.getHeaders(),
           signal,
@@ -228,8 +229,9 @@ class BraveSearch {
       const response = await axios.get<LocalDescriptionsSearchApiResponse>(
         `${this.baseUrl}/local/descriptions`,
         {
-          params: {
-            ids: ids.join(","),
+          params: { ids },
+          paramsSerializer: {
+            indexes: null
           },
           headers: this.getHeaders(),
           signal,


### PR DESCRIPTION
Hi,

For localPoiSearch the way the ids are current handled when the url is constructed it does not return any results for valid ids.

Currently ${this.baseUrl}/local/descriptions?ids=id1,id2
<img width="860" alt="poiNoResults" src="https://github.com/user-attachments/assets/383907ef-fae6-4e3f-95e9-8d8ad11e259a" />

It needs to be changed to  ${this.baseUrl}/local/descriptions?ids=id1&ids=id2
<img width="848" alt="poiSuccess" src="https://github.com/user-attachments/assets/b7c8b5d1-367f-4877-b813-7fc6b48e3f57" />

The same is true for how ids are handled in localDescriptionsSearch.

From the brave search api
<img width="893" alt="searchAPIDoc" src="https://github.com/user-attachments/assets/d8a2a869-4801-43d1-aac3-36865936a8b1" />


Regards,
Mike