### PR TITLE
Added video search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Brave Search API Wrapper
 
-A fully typed Brave Search API wrapper, providing easy access to web search, news search, image search, local POI search, and automatic polling for AI-generated web search summary feature.
+A fully typed Brave Search API wrapper, providing easy access to web search, news search, image search, video search, local POI search, and automatic polling for AI-generated web search summary feature.
 
 ## Installation
 
@@ -134,6 +134,18 @@ const newsSearchResults = await braveSearch.newsSearch("Ghibli ChatGPT", {
   extra_snippets: true, // Optional: Whether to include extra snippets (default is false)
 });
 console.log(newsSearchResults);
+```
+
+### Video Search
+
+Perform a Video Search using the 'videoSearch' method. Your IDE will provide type hints for the parameters and return types.
+
+```typescript
+const videoSearchResults = await braveSearch.videoSearch("Keyboard cat", {
+  count: 10, // Number of results to return
+  safesearch: "strict" // Optional: Filter for adult content (default is "moderate")
+  search_lang: "de" // Optional: Language of the search results (default is "en")
+})
 ```
 
 ## Search Options

--- a/src/braveSearch.ts
+++ b/src/braveSearch.ts
@@ -29,6 +29,8 @@ import {
   PollingOptions,
   SummarizerOptions,
   SummarizerSearchApiResponse,
+  VideoSearchApiResponse,
+  VideoSearchOptions,
   WebSearchApiResponse,
 } from "./types";
 
@@ -140,6 +142,36 @@ class BraveSearch {
     try {
       const response = await axios.get<NewsSearchApiResponse>(
         `${this.baseUrl}/news/search?`,
+        {
+          params: {
+            q: query,
+            ...this.formatOptions(options),
+          },
+          headers: this.getHeaders(),
+          signal,
+        },
+      );
+      return response.data;
+    } catch (error) {
+      const handledError = this.handleApiError(error);
+      throw handledError;
+    }
+  }
+
+  /**
+   * Performs a video search using the provided query and options.
+   * @param query The search query string.
+   * @param options Optional settings to configure the search behavior.
+   * @returns A promise that resolves to the video search results.
+   */
+  async videoSearch(
+    query: string,
+    options: VideoSearchOptions = {},
+    signal?: AbortSignal,
+  ) : Promise<VideoSearchApiResponse> {
+    try {
+      const response = await axios.get<VideoSearchApiResponse>(
+        `${this.baseUrl}/videos/search?`,
         {
           params: {
             q: query,
@@ -353,4 +385,6 @@ export {
   type ImageSearchApiResponse,
   type NewsSearchApiResponse,
   type NewsSearchOptions,
+  type VideoSearchApiResponse,
+  type VideoSearchOptions,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1488,6 +1488,21 @@ export interface VideoData {
    * @type {Thumbnail}
    */
   thumbnail: Thumbnail;
+  /**
+   * Whether the video requires a subscription.
+   * @type {boolean}
+   */
+  requires_subscription?: boolean;
+  /**
+   * A list of tags relevant to the video.
+   * @type {string[]}
+   */
+  tags?: string[];
+    /**
+   * A profile associated with the video.
+   * @type {Profile}
+   */
+  author?: Profile;
 }
 
 export interface MovieData {
@@ -2726,3 +2741,34 @@ export interface Image {
      */
     results: NewsResult[]
   }
+
+  /**
+   * Options for video search
+   * 
+   * https://api-dashboard.search.brave.com/app/documentation/video-search/query
+   */
+  export interface VideoSearchOptions extends Pick<BraveSearchOptions, 'country' | 'search_lang' | 'ui_lang' | 'count' | 'offset' | 'spellcheck' | 'safesearch' | 'freshness'> {
+  }
+
+  /**
+ * Response from the Brave Search API for video search.
+ *
+ * https://api-dashboard.search.brave.com/app/documentation/video-search/responses
+ */
+export interface VideoSearchApiResponse {
+  /**
+   * The type of search API result. The value is always video.
+   * @type {string}
+   */
+  type: 'video';
+  /**
+   * Video search query string.
+   * @type {Query}
+   */
+  query: Query;
+  /**
+   * The list of video results for the given query.
+   * @type {VideoResult[]}
+   */
+  results: VideoResult[];
+}


### PR DESCRIPTION
Hello,

I have added video search to match up with https://api-dashboard.search.brave.com/app/documentation/video-search/get-started.

Let me know if any other changes are needed.

With this additional, all we are missing is the Suggest API and Spellcheck API.

Mike